### PR TITLE
fix for classification()

### DIFF
--- a/R/classification.R
+++ b/R/classification.R
@@ -33,13 +33,12 @@ classification <- function(lcl, ucl, threshold, reference = 0) {
               is.numeric(threshold), noNA(threshold), is.number(reference),
               noNA(reference), all(lcl <= ucl))
   if (length(threshold) == 1) {
-    assert_that(-abs(threshold) < reference, reference < abs(threshold))
     threshold <- reference + c(-1, 1) * abs(threshold)
-  } else {
-    assert_that(length(threshold) == 2, min(threshold) < reference,
-                reference < max(threshold))
-    threshold <- sort(threshold)
   }
+  assert_that(length(threshold) == 2, min(threshold) < reference,
+              reference < max(threshold))
+  threshold <- sort(threshold)
+
   classification <- ifelse(
     ucl < threshold[2],
     ifelse(

--- a/R/classification.R
+++ b/R/classification.R
@@ -34,10 +34,11 @@ classification <- function(lcl, ucl, threshold, reference = 0) {
               noNA(reference), all(lcl <= ucl))
   if (length(threshold) == 1) {
     threshold <- reference + c(-1, 1) * abs(threshold)
+  } else {
+    assert_that(length(threshold) == 2, min(threshold) < reference,
+                reference < max(threshold))
+    threshold <- sort(threshold)
   }
-  assert_that(length(threshold) == 2, min(threshold) < reference,
-              reference < max(threshold))
-  threshold <- sort(threshold)
 
   classification <- ifelse(
     ucl < threshold[2],


### PR DESCRIPTION
The following example throws an error:

````
library(effectclass)
ds <- data.frame(
   lcl =        c(-5, -5, -5, -5, -2, -2, -2, 1, 1, 4),
   ucl =        c( 5,  2, -1, -4,  5,  2, -1, 5, 2, 5)
 )
ds$effect <- classification(lcl = ds$lcl, ucl = ds$ucl, threshold = 3, reference = 4)
````
Error: reference not less than abs(threshold)
Called from: assert_that(-abs(threshold) < reference, reference < abs(threshold))

This should however be valid because threshold will be translated to [4 - 3, 4 + 3] = [1,7] which by definition asserts that the reference is in between the threshold values. 

This PR contains a commit that fixes the issue.


